### PR TITLE
Adding namespace definition to the ebus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ set(CMAKE_CXX_STANDARD 20) # for concepts
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake")
 option(EBUS_ENABLE_TESTING "enable testing" ON)
 
+if(NOT DEFINED EBUS_NAMESPACE)
+  set(EBUS_NAMESPACE "ebus")
+endif()
+
+if (NOT DEFINED ITRV_NAMESPACE)
+  set(INTRUSIVE_NAMESPACE ${EBUS_NAMESPACE})
+endif()
+
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -22,6 +31,11 @@ add_library(ebus
 target_include_directories(ebus
   PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+target_compile_definitions(ebus PUBLIC
+  EBUS_NS=${EBUS_NAMESPACE}
+  INTRUSIVE_NS=${INTRUSIVE_NAMESPACE})
+
 
 if (${EBUS_ENABLE_TESTING})
   add_subdirectory(test)

--- a/include/ebus/ebus.hh
+++ b/include/ebus/ebus.hh
@@ -1,3 +1,8 @@
 #pragma once
+
+#ifndef EBUS_NS
+#    define EBUS_NS ebus
+#endif
+
 #include "internal/ebus.def.hh"
 #include "internal/ebus.inl.hh"

--- a/include/ebus/internal/ebus.def.hh
+++ b/include/ebus/internal/ebus.def.hh
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifndef INTRUSIVE_NS
+#    define INTRUSIVE_NS EBUS_NS
+#endif
 #include "ebus/memory/intrusive_list.hh"
 
 #include <cstddef>
@@ -13,7 +16,7 @@ concept has_function = requires(T t, function_t&& func, args_t&&... args) {
     { t.func(args...) };
 };
 
-namespace sp
+namespace EBUS_NS
 {
 
 enum ebus_type
@@ -127,4 +130,4 @@ private:
     };
 };
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/internal/ebus.inl.hh
+++ b/include/ebus/internal/ebus.inl.hh
@@ -5,7 +5,7 @@
 #include <functional>
 #include <utility>
 
-namespace sp
+namespace EBUS_NS
 {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -233,4 +233,4 @@ ebus<interface>::invoke(result_t& result, size_t id, function_t&& func, args_t&&
     }
 }
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/internal/event.def.hh
+++ b/include/ebus/internal/event.def.hh
@@ -1,11 +1,14 @@
 #pragma once
 
+#ifndef INTRUSIVE_NS
+#    define INTRUSIVE_NS EBUS_NS
+#endif
 #include "ebus/memory/intrusive_list.hh"
 
 #include <functional>
 #include <atomic>
 
-namespace sp
+namespace EBUS_NS
 {
 
 template <typename... args>
@@ -76,4 +79,4 @@ protected:
     mutable std::mutex m_handlers_lock;
 };
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/internal/event.inl.hh
+++ b/include/ebus/internal/event.inl.hh
@@ -3,7 +3,7 @@
 #include "event.def.hh"
 #include "ebus/memory/intrusive_list.hh"
 
-namespace sp
+namespace EBUS_NS
 {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,4 +144,4 @@ event<args...>::connect(handler& handler)
     m_head.push_back(handler.m_node);
 }
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/memory/intrusive_list.hh
+++ b/include/ebus/memory/intrusive_list.hh
@@ -1,10 +1,14 @@
 #pragma once
 
+#ifndef INTRUSIVE_NS
+#    define INTRUSIVE_NS ITRV_NS
+#endif
+
 #include <stdint.h>
 #include <stddef.h>
 #include <iterator>
 
-namespace sp
+namespace INTRUSIVE_NS
 {
 
 class intrusive_list_node;
@@ -326,4 +330,4 @@ public:
 //      reinterpret_cast< ptrdiff_t >( &( reinterpret_cast< T* >( 0 )->*member ) ) );
 // }
 
-} // namespace sp
+} // namespace INTRUSIVE_NS

--- a/include/ebus/memory/intrusive_ptr.hh
+++ b/include/ebus/memory/intrusive_ptr.hh
@@ -1,11 +1,15 @@
 #pragma once
 
-#include <concepts>
-#include <memory>
-#include <type_traits>
-#include <assert.h>
+#ifndef INTRUSIVE_NS
+#    define INTRUSIVE_NS ITRV_NS
+#endif
 
-namespace sp
+#include <concepts>
+#    include <memory>
+#    include <type_traits>
+#    include <assert.h>
+
+namespace INTRUSIVE_NS
 {
 
 /**
@@ -268,7 +272,7 @@ dynamic_pointer_cast(intrusive_ptr<U> const& p)
     return dynamic_cast<T*>(p.get());
 }
 
-} // namespace sp
+} // namespace INTRUSIVE_NS
 
 ///////////////////////////////////////////////////////////////////////////
 // hash support
@@ -278,9 +282,9 @@ namespace std
 {
 // hashing support for STL containers
 template <typename T>
-struct hash<sp::intrusive_ptr<T>>
+struct hash<INTRUSIVE_NS::intrusive_ptr<T>>
 {
-    inline size_t operator()(const sp::intrusive_ptr<T>& value) const
+    inline size_t operator()(const INTRUSIVE_NS::intrusive_ptr<T>& value) const
     {
         return hash<T*>()(value.get());
     }

--- a/include/ebus/memory/safe_queue.hh
+++ b/include/ebus/memory/safe_queue.hh
@@ -3,7 +3,7 @@
 #include <vector>
 #include <functional>
 
-namespace sp
+namespace EBUS_NS
 {
 
 ///@brief the safe_queue allows you to visit the
@@ -32,4 +32,4 @@ private:
     std::vector<T> m_executions;
 };
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/task.hh
+++ b/include/ebus/task.hh
@@ -5,7 +5,7 @@
 
 #include <ebus/ebus.hh>
 
-namespace sp
+namespace EBUS_NS
 {
 
 /**
@@ -45,4 +45,4 @@ struct task : public task_base, ebus_iface<iface_type>
 {
 };
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/include/ebus/task_worker.hh
+++ b/include/ebus/task_worker.hh
@@ -6,7 +6,7 @@
 #include <atomic>
 #include <semaphore>
 
-namespace sp
+namespace EBUS_NS
 {
 
 /**
@@ -26,4 +26,4 @@ protected:
     std::atomic_bool                     m_live = true;
 };
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/src/task/task_worker.cc
+++ b/src/task/task_worker.cc
@@ -1,7 +1,7 @@
 #include "ebus/task_worker.hh"
 #include <atomic>
 
-namespace sp
+namespace EBUS_NS
 {
 
 void
@@ -40,4 +40,4 @@ task_worker::add_task(intrusive_ptr<task_base> task)
     return true;
 }
 
-} // namespace sp
+} // namespace EBUS_NS

--- a/test/test_ebus.cc
+++ b/test/test_ebus.cc
@@ -2,8 +2,8 @@
 #include <ebus/ebus.hh>
 #include <iostream>
 
-template <sp::ebus_type TYPE>
-class sample_interface : public sp::ebus_iface<TYPE>
+template <EBUS_NS::ebus_type TYPE>
+class sample_interface : public EBUS_NS::ebus_iface<TYPE>
 {
 public:
     virtual void event0(int)   = 0;
@@ -11,18 +11,19 @@ public:
     virtual void event1(std::string&) = 0;
 };
 
-template <sp::ebus_type TYPE>
-using sample_ebus = sp::ebus<sample_interface<TYPE>>;
+template <EBUS_NS::ebus_type TYPE>
+using sample_ebus = EBUS_NS::ebus<sample_interface<TYPE>>;
 
-using sample_id_bus = sp::ebus<sample_interface<sp::ONE2ONE>>;
+using sample_id_bus = EBUS_NS::ebus<sample_interface<EBUS_NS::ONE2ONE>>;
 
-using sample_id_interface = sample_interface<sp::ONE2ONE>;
+using sample_id_interface = sample_interface<EBUS_NS::ONE2ONE>;
 
 static const size_t ID = 100;
 //////////////////////////////////////////////////////////////////////////////////////
 // ID
 //////////////////////////////////////////////////////////////////////////////////////
-class sample_id_ebus_handler : public sp::ebus_handler<sample_interface<sp::ONE2ONE>>
+class sample_id_ebus_handler
+    : public EBUS_NS::ebus_handler<sample_interface<EBUS_NS::ONE2ONE>>
 {
 public:
     sample_id_ebus_handler()
@@ -70,11 +71,11 @@ test_id()
 // global
 //////////////////////////////////////////////////////////////////////////////////////
 
-using sample_type_bus = sp::ebus<sample_interface<sp::GLOBAL>>;
+using sample_type_bus = EBUS_NS::ebus<sample_interface<EBUS_NS::GLOBAL>>;
 
-using sample_type_interface = sample_interface<sp::GLOBAL>;
+using sample_type_interface = sample_interface<EBUS_NS::GLOBAL>;
 
-class sample_typed_ebus_handler : public sp::ebus_handler<sample_type_interface>
+class sample_typed_ebus_handler : public EBUS_NS::ebus_handler<sample_type_interface>
 {
 public:
     sample_typed_ebus_handler()
@@ -119,10 +120,10 @@ test_typed()
 // group
 //////////////////////////////////////////////////////////////////////////////////////
 
-using sample_group_bus       = sp::ebus<sample_interface<sp::GROUP>>;
-using sample_group_interface = sample_interface<sp::GROUP>;
+using sample_group_bus       = EBUS_NS::ebus<sample_interface<EBUS_NS::GROUP>>;
+using sample_group_interface = sample_interface<EBUS_NS::GROUP>;
 
-class sample_group_ebus_handler : public sp::ebus_handler<sample_group_interface>
+class sample_group_ebus_handler : public EBUS_NS::ebus_handler<sample_group_interface>
 {
 public:
     sample_group_ebus_handler(size_t id) :

--- a/test/test_ebus_ref.cc
+++ b/test/test_ebus_ref.cc
@@ -19,7 +19,7 @@ private:
     int m_value;
 };
 
-class sample_interface : public sp::ebus_iface<sp::ebus_type::GLOBAL>
+class sample_interface : public EBUS_NS::ebus_iface<EBUS_NS::ebus_type::GLOBAL>
 {
 public:
     virtual void event0(const sample_class& ref) = 0;
@@ -27,9 +27,9 @@ public:
     virtual bool request0(const sample_class& ref) = 0;
 };
 
-typedef sp::ebus<sample_interface> sample_bus;
+typedef EBUS_NS::ebus<sample_interface> sample_bus;
 
-class sample_ebus_handler : public sp::ebus_handler<sample_interface>
+class sample_ebus_handler : public EBUS_NS::ebus_handler<sample_interface>
 {
 public:
     sample_ebus_handler(int value) :

--- a/test/test_event.cc
+++ b/test/test_event.cc
@@ -1,8 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include "ebus/event.hh"
 
-typedef sp::event<> null_event;
-static int          counter = 0;
+typedef EBUS_NS::event<>   null_event;
+static int                 counter = 0;
 static null_event          null_event0;
 static null_event::handler handler([]() { counter++; }, &null_event0);
 

--- a/test/test_task.cc
+++ b/test/test_task.cc
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <thread>
 
-class test_task : public sp::task<sp::GLOBAL>
+class test_task : public EBUS_NS::task<EBUS_NS::GLOBAL>
 {
 public:
     test_task(int id) :
@@ -62,7 +62,7 @@ private:
 bool
 test_task_worker()
 {
-    sp::task_worker worker;
+    EBUS_NS::task_worker worker;
 
     std::thread worker_thread([&worker]() { worker(); });
     worker_thread.detach();
@@ -72,7 +72,7 @@ test_task_worker()
 
     for (int i = 0; i < 10; i++)
     {
-        worker.add_task(sp::intrusive_ptr<test_task>(new test_task(i)));
+        worker.add_task(EBUS_NS::intrusive_ptr<test_task>(new test_task(i)));
         std::cout << "adding task " << i << std::endl;
     }
 


### PR DESCRIPTION
This patch allows custom namespace applied to ebus and intrusive interface. This allows me to include intrusive_ptr in another project without interfering with ebus headers. Simply by setup the namespace to a different one, both ebus and intrusive_ptr will use that namespace.