### PR TITLE
priority_t: explicitly declaring a priority_t

### DIFF
--- a/include/ebus/internal/ebus.def.hh
+++ b/include/ebus/internal/ebus.def.hh
@@ -99,12 +99,24 @@ class ebus_handler : public interface
 {
     friend class ebus<interface>;
 
+public:
+    struct priority_t
+    {
+        float m_priority = 0.0f;
+        priority_t() {}
+        explicit priority_t(float p) : // explicit so no implicit conversion
+            m_priority(p)
+        {
+        }
+        inline float val() const { return m_priority; }
+    };
+
 protected:
     /// connect via handler type. In this case we only allows one_to_one connection
-    void connect(float priority = 0.0f);
+    void connect(priority_t p = {});
 
     // connect via id. This is additional
-    bool connect(size_t id, float priority = 0.0f);
+    bool connect(size_t id, priority_t p = {});
     bool disconnect();
 
     static constexpr bool is_one2one() { return interface::type == ebus_type::ONE2ONE; }

--- a/include/ebus/internal/ebus.inl.hh
+++ b/include/ebus/internal/ebus.inl.hh
@@ -46,7 +46,7 @@ ebus_handler<interface>::insert_handler_at(intrusive_list& head,
  */
 template <EBUS_IFACE interface>
 void
-ebus_handler<interface>::connect(float priority)
+ebus_handler<interface>::connect(priority_t p)
 {
     static_assert(interface::type == ebus_type::GLOBAL,
                   "non-id connect() are reserved for type based ebus handlers");
@@ -54,7 +54,7 @@ ebus_handler<interface>::connect(float priority)
     ctx&   ctx = get_context();
 
     std::scoped_lock<std::mutex> lock(ctx.m_lock);
-    insert_handler_at(ctx.m_handlers, *this, priority);
+    insert_handler_at(ctx.m_handlers, *this, p.val());
 }
 
 /**
@@ -62,7 +62,7 @@ ebus_handler<interface>::connect(float priority)
  */
 template <EBUS_IFACE interface>
 bool
-ebus_handler<interface>::connect(size_t id, float priority)
+ebus_handler<interface>::connect(size_t id, priority_t p)
 {
     static_assert(interface::type == ebus_type::ONE2ONE ||
                       interface::type == ebus_type::GROUP,
@@ -82,7 +82,7 @@ ebus_handler<interface>::connect(size_t id, float priority)
     }
     else // group case
     {
-        insert_handler_at(ctx.m_group_handlers[id], *this, priority);
+        insert_handler_at(ctx.m_group_handlers[id], *this, p.val());
     }
 
     return true;

--- a/test/test_ebus_ref.cc
+++ b/test/test_ebus_ref.cc
@@ -36,7 +36,7 @@ public:
         m_value(value)
     {
         std::cout << "typed bus connected" << std::endl;
-        connect((float)value);
+        connect(priority_t((float)m_value));
     }
     ~sample_ebus_handler()
     {


### PR DESCRIPTION
So that connect(size_t id) does not get implicitly conversion to connect();