### PR TITLE
constexpr ebus_priority_t

### DIFF
--- a/include/ebus/internal/ebus.def.hh
+++ b/include/ebus/internal/ebus.def.hh
@@ -94,29 +94,41 @@ private:
     handler_t& find_first_handler();
 };
 
+struct ebus_priority_t
+{
+    const float m_priority;
+
+    constexpr ebus_priority_t() :
+        m_priority(0.0f)
+    {
+    }
+    constexpr explicit ebus_priority_t(float p) : // explicit so no implicit conversion
+        m_priority(p)
+    {
+    }
+    constexpr inline float val() const { return m_priority; }
+
+    constexpr ebus_priority_t operator+(float another) const
+    {
+        return ebus_priority_t(m_priority + another);
+    }
+    constexpr ebus_priority_t operator-(float another) const
+    {
+        return ebus_priority_t(m_priority - another);
+    }
+};
+
 template <EBUS_IFACE interface>
 class ebus_handler : public interface
 {
     friend class ebus<interface>;
 
-public:
-    struct priority_t
-    {
-        float m_priority = 0.0f;
-        priority_t() {}
-        explicit priority_t(float p) : // explicit so no implicit conversion
-            m_priority(p)
-        {
-        }
-        inline float val() const { return m_priority; }
-    };
-
 protected:
     /// connect via handler type. In this case we only allows one_to_one connection
-    void connect(priority_t p = {});
+    void connect(ebus_priority_t p = {});
 
     // connect via id. This is additional
-    bool connect(size_t id, priority_t p = {});
+    bool connect(size_t id, ebus_priority_t p = {});
     bool disconnect();
 
     static constexpr bool is_one2one() { return interface::type == ebus_type::ONE2ONE; }

--- a/include/ebus/internal/ebus.inl.hh
+++ b/include/ebus/internal/ebus.inl.hh
@@ -46,7 +46,7 @@ ebus_handler<interface>::insert_handler_at(intrusive_list& head,
  */
 template <EBUS_IFACE interface>
 void
-ebus_handler<interface>::connect(priority_t p)
+ebus_handler<interface>::connect(ebus_priority_t p)
 {
     static_assert(interface::type == ebus_type::GLOBAL,
                   "non-id connect() are reserved for type based ebus handlers");
@@ -62,7 +62,7 @@ ebus_handler<interface>::connect(priority_t p)
  */
 template <EBUS_IFACE interface>
 bool
-ebus_handler<interface>::connect(size_t id, priority_t p)
+ebus_handler<interface>::connect(size_t id, ebus_priority_t p)
 {
     static_assert(interface::type == ebus_type::ONE2ONE ||
                       interface::type == ebus_type::GROUP,

--- a/test/test_ebus_ref.cc
+++ b/test/test_ebus_ref.cc
@@ -36,7 +36,7 @@ public:
         m_value(value)
     {
         std::cout << "typed bus connected" << std::endl;
-        connect(priority_t((float)m_value));
+        connect(EBUS_NS::ebus_priority_t((float)m_value));
     }
     ~sample_ebus_handler()
     {


### PR DESCRIPTION
- the nested priority_t is annoying when you inherit multiple handles.
- constexpr everyting in ebus_priority_t