### PR TITLE
ebus_handler: auto disconnect at destructor

### DIFF
--- a/include/ebus/internal/ebus.def.hh
+++ b/include/ebus/internal/ebus.def.hh
@@ -109,6 +109,9 @@ protected:
 
     static constexpr bool is_one2one() { return interface::type == ebus_type::ONE2ONE; }
 
+public:
+    ~ebus_handler() { disconnect(); }
+
 private:
     INTRUSIVE_NS::intrusive_list_node m_node;
     ssize_t             m_id = -1;

--- a/include/ebus/internal/ebus.def.hh
+++ b/include/ebus/internal/ebus.def.hh
@@ -110,7 +110,7 @@ protected:
     static constexpr bool is_one2one() { return interface::type == ebus_type::ONE2ONE; }
 
 public:
-    ~ebus_handler() { disconnect(); }
+    virtual ~ebus_handler() { disconnect(); }
 
 private:
     INTRUSIVE_NS::intrusive_list_node m_node;


### PR DESCRIPTION
We may want to make it copy-able or movable in the future. For now it is sufficient